### PR TITLE
VOID-46 basic update all summoners

### DIFF
--- a/src/main/java/st/tiy/voidapp/model/domain/match/team/Participant.java
+++ b/src/main/java/st/tiy/voidapp/model/domain/match/team/Participant.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import st.tiy.voidapp.model.domain.match.team.runes.Perks;
@@ -16,6 +17,7 @@ import java.util.Map;
 @Entity
 @Getter
 @Setter
+@EqualsAndHashCode
 public class Participant {
 
 	@Id

--- a/src/main/java/st/tiy/voidapp/queue/TaskProcessingService.java
+++ b/src/main/java/st/tiy/voidapp/queue/TaskProcessingService.java
@@ -30,8 +30,8 @@ public class TaskProcessingService {
 	private void executeTask(VoidTask<?> task) {
 		switch (task) {
 			case BasicSummonerProcessTask processTask -> {
-				BasicSummonerProcessTaskParams params = processTask.getParameters();
-				// Pull basic summoner
+				BasicSummonerProcessTaskParams p = processTask.getParameters();
+				this.summonerService.updateBasicSummoner(p.server(), p.gameName(), p.tagLine());
 			}
 			default -> log.error("Void task type not recognized {}", task);
 		}

--- a/src/main/java/st/tiy/voidapp/queue/task/summonerfetch/BasicSummonerProcessTaskParams.java
+++ b/src/main/java/st/tiy/voidapp/queue/task/summonerfetch/BasicSummonerProcessTaskParams.java
@@ -1,7 +1,9 @@
 package st.tiy.voidapp.queue.task.summonerfetch;
 
+import lombok.Builder;
 import st.tiy.voidapp.api.Server;
 
+@Builder
 public record BasicSummonerProcessTaskParams(Server server, String gameName, String tagLine) {
 
 }


### PR DESCRIPTION
When a summoner updates and gets new matches, we gather unique summoners and place them in background process queue to fetch basic summoner info.

This reduces friction for summoners from those matches who might want to try Void out only to find Update screen and go back to alternative before giving void a try.